### PR TITLE
PAS-380: Skip span recording if not marked as sampled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 *Log of significant changes, especially those affecting the supported API.*
 
 ## vNext
+* Omit non-sampled spans from report (#290)
 
 ## 0.33.0
 * Upgrade async (#288)

--- a/src/imp/span_imp.js
+++ b/src/imp/span_imp.js
@@ -133,6 +133,10 @@ export default class SpanImp extends opentracing.Span {
         return this;
     }
 
+    isSampled() {
+        return this._ctx._sampled;
+    }
+
     /**
      * Returns a URL to the trace containing this span.
      *
@@ -194,7 +198,10 @@ export default class SpanImp extends opentracing.Span {
             }).finish();
         }
 
-        this._tracerImp._addSpanRecord(this);
+        // Only record span if sampled
+        if (this.isSampled()) {
+            this._tracerImp._addSpanRecord(this);
+        }
     }
 
     _toThrift() {


### PR DESCRIPTION
The current implementation acknowledges the `ot-tracer-sampled` header and propagates it as a bit in the SpanContext for the root and any child spans. However, it doesn't do anything useful with it. It still ships these spans to the collector, and doesn't serialize the information into the report, so the collectors don't do anything with it either.

This change simply skips the recording of the span in the report if it is not marked as sampled. The default is true, so the only way this gets set to false is if the incoming request has `ot-tracer-sampled` set to `0`, `'0'`, `false`, or `'false'`.